### PR TITLE
Fix README trailing line

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,3 @@ the start of the search.
 The application expects a connection string for Amazon Redshift to be provided
 via the `REDSHIFT_URL` environment variable. Set this variable to a valid
 SQLAlchemy connection URI before running the analysis scripts.
-     
-     


### PR DESCRIPTION
## Summary
- remove stray prompt line so README ends right after the last paragraph

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685559731e30832a9856185772ce3c0a