### PR TITLE
Refactor pipeline to run in-process

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,10 @@
+import os
+import pymysql
+
+host = os.getenv('host_RDS')
+PORT = int(os.getenv('RDS_port'))
+USER = os.getenv('RDS_user')
+PASS = os.getenv('RDS_pass')
+DBNAME = os.getenv('RDS_db')
+
+conn = pymysql.connect(host=host, user=USER, port=PORT, passwd=PASS, database=DBNAME)

--- a/backend/sendMail.py
+++ b/backend/sendMail.py
@@ -1,6 +1,6 @@
 import pandas as pd, os
 import logging
-from .app import conn
+from .db import conn
 from .Rds_Handle import update_requested_study, get_hash_id
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail


### PR DESCRIPTION
## Summary
- centralize DB connection in new `db.py`
- use threading and direct function calls instead of spawning subprocesses
- refactor search and analysis scripts into callable functions
- update imports across modules

## Testing
- `python -m py_compile backend/app.py backend/SearchTweets.py backend/SentimentAnalysis.py backend/GenderClassification.py backend/streamApi.py backend/sendMail.py backend/db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555f87f34c832aa0ff49ea5fba728a